### PR TITLE
Fix with goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Install: `go get -u github.com/Dviih/Channel`
 
 ## Usage
+- `Send[T]` - sends as a parameter.
 - `Sender[T]` - creates a new sender channel.
 - `Receiver[T]` - creates a new receiver channel.
 - `New[T](size)` - creates a *Channel instance.

--- a/channel.go
+++ b/channel.go
@@ -38,8 +38,8 @@ func (channel *Channel[T]) Sender() chan<- T {
 		for {
 			select {
 			case data := <-c:
-				for _, p := range channel.receivers {
-					p <- data
+				for _, receiver := range channel.receivers {
+					receiver <- data
 				}
 			}
 		}

--- a/channel.go
+++ b/channel.go
@@ -23,6 +23,14 @@ type Channel[T interface{}] struct {
 	receivers []chan T
 }
 
+func (channel *Channel[T]) Send(v ...T) {
+	for _, t := range v {
+		for _, receiver := range channel.receivers {
+			receiver <- t
+		}
+	}
+}
+
 func (channel *Channel[T]) Sender() chan<- T {
 	c := make(chan T, channel.size)
 


### PR DESCRIPTION
This pull request does some fixes usage with goroutines and adds a method `Send` which is fairly better than creating a new channel but for compatibility reasons there will still be a `Sender()` return a `chan T`.
(Tests are very messed up and I wish to make something better soon)