### PR TITLE
Options

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -19,7 +19,7 @@
 package Channel
 
 type Channel[T interface{}] struct {
-	size      int
+	options   *Options
 	receivers []chan T
 }
 
@@ -27,6 +27,12 @@ func (channel *Channel[T]) Send(v ...T) {
 	for _, t := range v {
 		for _, receiver := range channel.receivers {
 			receiver <- t
+type Options struct {
+	size    int
+	timeout time.Duration
+	resend  bool
+}
+
 		}
 	}
 }

--- a/channel.go
+++ b/channel.go
@@ -18,6 +18,10 @@
 
 package Channel
 
+import (
+	"time"
+)
+
 type Channel[T interface{}] struct {
 	options   *Options
 	receivers []chan T

--- a/channel.go
+++ b/channel.go
@@ -62,8 +62,10 @@ func (channel *Channel[T]) Receiver() <-chan T {
 	return c
 }
 
-func New[T interface{}](size int) *Channel[T] {
+func New[T interface{}](v ...Option) *Channel[T] {
+	options := &Options{}
+
 	return &Channel[T]{
-		size: size,
+		options: options,
 	}
 }

--- a/channel.go
+++ b/channel.go
@@ -38,7 +38,7 @@ type Options struct {
 }
 
 func (channel *Channel[T]) Sender() chan<- T {
-	c := make(chan T, channel.size)
+	c := make(chan T, channel.options.size)
 
 	go func() {
 		for {
@@ -55,10 +55,9 @@ func (channel *Channel[T]) Sender() chan<- T {
 }
 
 func (channel *Channel[T]) Receiver() <-chan T {
-	c := make(chan T, channel.size)
+	c := make(chan T, channel.options.size)
 
 	channel.receivers = append(channel.receivers, c)
-
 	return c
 }
 

--- a/channel.go
+++ b/channel.go
@@ -65,6 +65,17 @@ func (channel *Channel[T]) Receiver() <-chan T {
 func New[T interface{}](v ...Option) *Channel[T] {
 	options := &Options{}
 
+	for _, option := range v {
+		switch option.Name() {
+		case "size":
+			options.size = option.Value().(int)
+		case "timeout":
+			options.timeout = option.Value().(time.Duration)
+		case "resend":
+			options.resend = true
+		}
+	}
+
 	return &Channel[T]{
 		options: options,
 	}

--- a/option.go
+++ b/option.go
@@ -1,0 +1,22 @@
+/*
+ *     Channels with multiple receivers and multiple senders capacity.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package Channel
+
+import "time"
+

--- a/option.go
+++ b/option.go
@@ -25,3 +25,15 @@ type Option interface {
 	Value() interface{}
 }
 
+type optionSize struct {
+	size int
+}
+
+func (*optionSize) Name() string {
+	return "size"
+}
+
+func (size *optionSize) Value() interface{} {
+	return size.size
+}
+

--- a/option.go
+++ b/option.go
@@ -37,3 +37,7 @@ func (size *optionSize) Value() interface{} {
 	return size.size
 }
 
+func OptionSize(size int) Option {
+	return &optionSize{size: size}
+}
+

--- a/option.go
+++ b/option.go
@@ -41,3 +41,19 @@ func OptionSize(size int) Option {
 	return &optionSize{size: size}
 }
 
+type optionTimeout struct {
+	timeout time.Duration
+}
+
+func (*optionTimeout) Name() string {
+	return "timeout"
+}
+
+func (timeout *optionTimeout) Value() interface{} {
+	return timeout.timeout
+}
+
+func OptionTimeout(timeout time.Duration) Option {
+	return &optionTimeout{timeout: timeout}
+}
+

--- a/option.go
+++ b/option.go
@@ -57,3 +57,16 @@ func OptionTimeout(timeout time.Duration) Option {
 	return &optionTimeout{timeout: timeout}
 }
 
+type optionResend struct{}
+
+func (*optionResend) Name() string {
+	return "resend"
+}
+
+func (*optionResend) Value() interface{} {
+	return true
+}
+
+func OptionResend() Option {
+	return &optionResend{}
+}

--- a/option.go
+++ b/option.go
@@ -20,3 +20,8 @@ package Channel
 
 import "time"
 
+type Option interface {
+	Name() string
+	Value() interface{}
+}
+


### PR DESCRIPTION
This pull request replaces the old `Channel[T].size` with `Options` which is fairly better and adds other options.
- Size: The size for buffered channels. (0 is default)
- Timeout: It is an option to be used alongside `Try` which is coming in a future PR.
- Resend: Within timeout it will be recalled for new receivers.