### PR TITLE
Faster Tests

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -28,13 +28,13 @@ import (
 
 const (
 	times    = 5
-	duration = time.Second
+	duration = time.Microsecond
 )
 
 var (
 	expected uint64
 
-	channel     = New[uint64]()
+	channel     = New[uint64](OptionTimeout(10 * time.Microsecond))
 	ctx, cancel = context.WithCancel(context.Background())
 )
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -45,9 +45,7 @@ func receiver(t *testing.T, id int, c <-chan uint64) {
 		select {
 		case data := <-c:
 			if data != expected {
-				t.Fail()
 				t.Errorf("Receiver %d expected %d but got %d", id, expected, data)
-
 				return
 			}
 


### PR DESCRIPTION
An enhancement for tests would it be to run faster and this is very much achievable by simply removing delay to ensure Go is slow enough to not reassign the expected variable, although some workaround could be done but no and a buffered channel would be the solution in this case.
A timeout of 10 microseconds is more than enough and a microsecond per iteration too. (Hope GitHub workflow agrees too)